### PR TITLE
Precompute symbolic matrix to hold jacobian

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies
-      run: sudo apt install pkg-config libfreetype6-dev libfontconfig1-devel
+      run: sudo apt install pkg-config libfreetype6-dev libfontconfig1-dev
     - name: Format
       run: cargo fmt --check --verbose
     - name: Linting

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Dependencies
+      run: sudo apt install pkg-config libfreetype6-dev libfontconfig1-devel
     - name: Format
       run: cargo fmt --check --verbose
     - name: Linting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tiny-solver"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
-authors = ["Powei Lin <poweilin1994@gmail.com>"]
+authors = ["Powei Lin <poweilin1994@gmail.com>, Hossam R. <hrabbouh@gmail.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 description = "Factor graph solver"

--- a/src/optimizer/gauss_newton_optimizer.rs
+++ b/src/optimizer/gauss_newton_optimizer.rs
@@ -43,16 +43,29 @@ impl optimizer::Optimizer for GaussNewtonOptimizer {
             LinearSolverType::SparseQR => Box::new(linear::SparseQRSolver::new()),
         };
 
+        let symbolic_structure = problem.build_symbolic_structure(
+            &parameter_blocks,
+            total_variable_dimension,
+            &variable_name_to_col_idx_dict,
+        );
+
         let mut last_err: f64 = 1.0;
 
         for i in 0..opt_option.max_iteration {
+            let start = Instant::now();
             let (residuals, jac) = problem.compute_residual_and_jacobian(
                 &parameter_blocks,
                 &variable_name_to_col_idx_dict,
                 total_variable_dimension,
+                &symbolic_structure,
             );
             let current_error = residuals.norm_l2();
-            trace!("iter:{} total err:{}", i, current_error);
+            trace!(
+                "iter:{}, total err:{}, duration: {:?}",
+                i,
+                current_error,
+                start.elapsed()
+            );
 
             if current_error < opt_option.min_error_threshold {
                 trace!("error too low");

--- a/src/optimizer/levenberg_marquardt_optimizer.rs
+++ b/src/optimizer/levenberg_marquardt_optimizer.rs
@@ -67,6 +67,12 @@ impl optimizer::Optimizer for LevenbergMarquardtOptimizer {
         // With LM, rather than solving A * dx = b for dx, we solve for (A + lambda * diag(A)) dx = b.
         let mut jacobi_scaling_diagonal: Option<faer::sparse::SparseColMat<usize, f64>> = None;
 
+        let s = problem.build_symbolic_structure(
+            &parameter_blocks,
+            total_variable_dimension,
+            &variable_name_to_col_idx_dict,
+        );
+
         // Damping parameter (a.k.a lambda / Marquardt parameter)
         let mut u = 1.0 / self.initial_trust_region_radius;
 
@@ -76,6 +82,7 @@ impl optimizer::Optimizer for LevenbergMarquardtOptimizer {
                 &parameter_blocks,
                 &variable_name_to_col_idx_dict,
                 total_variable_dimension,
+                &s,
             );
 
             if i == 0 {

--- a/src/optimizer/levenberg_marquardt_optimizer.rs
+++ b/src/optimizer/levenberg_marquardt_optimizer.rs
@@ -193,7 +193,7 @@ impl optimizer::Optimizer for LevenbergMarquardtOptimizer {
                 } else {
                     // If there's too much divergence, reduce the trust region and try again with the same parameters.
                     u *= 2.0;
-                    println!("u {}", u);
+                    trace!("u {}", u);
                 }
             } else {
                 log::debug!("solve ax=b failed");

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -317,7 +317,7 @@ impl Problem {
         let mut local_jacobian_list = Vec::new();
 
         for (i, var_key) in residual_block.variable_key_list.iter().enumerate() {
-            if let Some(_) = variable_name_to_col_idx_dict.get(var_key) {
+            if variable_name_to_col_idx_dict.contains_key(var_key) {
                 let (variable_local_idx, var_size) = variable_local_idx_size_list[i];
                 let variable_jac = jac.view((0, variable_local_idx), (jac.shape().0, var_size));
                 for row_idx in 0..jac.shape().0 {
@@ -325,6 +325,8 @@ impl Problem {
                         local_jacobian_list.push(variable_jac[(row_idx, col_idx)]);
                     }
                 }
+            } else {
+                panic!("Missing key {} in variable-to-column-index mapping", var_key);
             }
         }
 

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -233,8 +233,7 @@ impl Problem {
                     residual_block,
                     parameter_blocks,
                     variable_name_to_col_idx_dict,
-                    &total_residual,
-                    &total_variable_dimension,
+                    &total_residual
                 )
             })
             .flatten()
@@ -293,7 +292,6 @@ impl Problem {
         parameter_blocks: &HashMap<String, ParameterBlock>,
         variable_name_to_col_idx_dict: &HashMap<String, usize>,
         total_residual: &Arc<Mutex<na::DVector<f64>>>,
-        total_variable_dimension: &usize,
     ) -> Vec<JacobianValue> {
         let mut params = Vec::new();
         let mut variable_local_idx_size_list = Vec::<(usize, usize)>::new();
@@ -316,8 +314,7 @@ impl Problem {
                 .copy_from(&res);
         }
 
-        let mut local_jacobian_list =
-            Vec::with_capacity(residual_block.dim_residual * total_variable_dimension);
+        let mut local_jacobian_list = Vec::new();
 
         for (i, var_key) in residual_block.variable_key_list.iter().enumerate() {
             if let Some(_) = variable_name_to_col_idx_dict.get(var_key) {

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -326,7 +326,10 @@ impl Problem {
                     }
                 }
             } else {
-                panic!("Missing key {} in variable-to-column-index mapping", var_key);
+                panic!(
+                    "Missing key {} in variable-to-column-index mapping",
+                    var_key
+                );
             }
         }
 

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -233,7 +233,7 @@ impl Problem {
                     residual_block,
                     parameter_blocks,
                     variable_name_to_col_idx_dict,
-                    &total_residual
+                    &total_residual,
                 )
             })
             .flatten()

--- a/tests/test_problem.rs
+++ b/tests/test_problem.rs
@@ -120,11 +120,17 @@ mod tests {
         let variable_name_to_col_idx_dict =
             problem.get_variable_name_to_col_idx_dict(&parameter_blocks);
         let total_variable_dimension = parameter_blocks.values().map(|p| p.tangent_size()).sum();
+        let symbolic_structure = problem.build_symbolic_structure(
+            &parameter_blocks,
+            total_variable_dimension,
+            &variable_name_to_col_idx_dict,
+        );
 
         let (residuals, jac) = problem.compute_residual_and_jacobian(
             &parameter_blocks,
             &variable_name_to_col_idx_dict,
             total_variable_dimension,
+            &symbolic_structure,
         );
 
         assert_eq!(residuals.nrows(), 3);


### PR DESCRIPTION
This PR allows the optimizer to pre-compute a symbolic matrix to hold the Jacobian. This ends up consistently shedding time at each iteration of the optimization loop, across all examples, by invoking `SparseColMat::new_from_order_values` instead of `SparseColMat::try_new_from_triplets`. 

Since the original insertion order must be respected to make use of the symbolic matrix, we've moved away from a shared list of jacobian values (which may have items inserted into it in any order) to each residual block returning a sublist of values. These sublists are then flattened in the same order as the residual blocks.

Note: compiling the tests in CI/CD was failing because of the plotting library, installing the right native dependencies seems to fix it.
